### PR TITLE
chore: upgrade Kubernetes v1.34.5 → v1.35.4

### DIFF
--- a/kubernetes/apps/kube-system/system-upgrade/upgrades/kubernetes.yaml
+++ b/kubernetes/apps/kube-system/system-upgrade/upgrades/kubernetes.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.34.5
+    version: v1.35.4

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.7
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.34.5
+kubernetesVersion: v1.35.4


### PR DESCRIPTION
## 升级路径

v1.34.5 → v1.35.4（单 minor 版本跳跃）

## 改动

- `talos/talenv.yaml` — kubernetesVersion 更新
- `kubernetes/apps/kube-system/system-upgrade/upgrades/kubernetes.yaml` — kubelet 版本更新

## 注意

- Talos v1.12.7 不变
- 后续可再升 v1.36.0（关闭 #333）

Related: #333